### PR TITLE
Fix symbolic link creation in capistrano deployment

### DIFF
--- a/generators/server/templates/devops-symfony/deploy/tasks/yarn.cap
+++ b/generators/server/templates/devops-symfony/deploy/tasks/yarn.cap
@@ -4,7 +4,7 @@ namespace :yarn do
       within fetch(:yarn_target_path, release_path) do
         with fetch(:yarn_env_variables, {}) do
           execute fetch(:yarn_bin), 'build'
-          execute 'ln', '-s', './build', '../web/build'
+          execute 'ln', '-s', '../client/build', '../web/build'
         end
       end
     end


### PR DESCRIPTION
When deploying for the first time, my front end was unavailable because the symbolic link web/build/ supposed to redirect to client/build was in fact redirecting web/build/ to itself.

This PR should fix the symbolic link creation and redirect to the correct folder.