### PR TITLE
Fix nginx conf for PWA

### DIFF
--- a/generators/server/templates/devops-symfony/provisioning/roles/ubuntu-symfony-nginx/templates/etc/nginx/conf.d/prodconf
+++ b/generators/server/templates/devops-symfony/provisioning/roles/ubuntu-symfony-nginx/templates/etc/nginx/conf.d/prodconf
@@ -87,6 +87,10 @@ server {
       return 301 /build/static/$1;
     }
 
+    location ~ ^\/(.[^\/]*\.(json|ico|js))$ {
+      rewrite ^\/(.[^\/]*\.(json|ico|js))$ /build/$1 last;
+    }
+
     location ~* \.(css|txt|xml|js|gif|jpe?g|png|ico)$ {
         expires 1y;
         log_not_found off;

--- a/generators/server/templates/devops-symfony/provisioning/roles/ubuntu-symfony-nginx/templates/etc/nginx/conf.d/vagrantconf
+++ b/generators/server/templates/devops-symfony/provisioning/roles/ubuntu-symfony-nginx/templates/etc/nginx/conf.d/vagrantconf
@@ -87,6 +87,10 @@ server {
       return 301 /build/static/$1;
     }
 
+    location ~ ^\/(.[^\/]*\.(json|ico|js))$ {
+      rewrite ^\/(.[^\/]*\.(json|ico|js))$ /build/$1 last;
+    }
+
     location ~* \.(css|txt|xml|js|gif|jpe?g|png|ico)$ {
         expires 1y;
         log_not_found off;


### PR DESCRIPTION
When deploying the app, I couldn't install it like a PWA. The problem was `manifest.json`, `favicon.ico` and `service-worker.js` couldn't be found : those files were at the root of the build folder, and no nginx config allowed to reach them.

This should fix the issue.