### PR TITLE
Update theodo-stack example to work with create-react-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ npm install -g theodo-stack-generator
 
 - Create an **empty** directory and run the generator:
 ```
-mkdir myApp && cd myApp
+mkdir my-app && cd my-app
 nvm use 8.4.0
 yo theodo-stack
 ```
@@ -92,4 +92,3 @@ This generator can be improved in many ways, PR are welcome! [here](https://gith
   - Change the code
   - Generate a new project
   - See if your new project works
-


### PR DESCRIPTION
When I launch the given commands, I have this error:

```
The react app cannot be created in a folder with a name containing capital letters
Error theodo-stack 

Please rename your client folder to a lowercase name
```

This fixes the issue.