### PR TITLE
Remove redundant (Y/n) message

### DIFF
--- a/generators/react/index.js
+++ b/generators/react/index.js
@@ -15,7 +15,7 @@ class StackGenerator extends Generator {
         type: 'confirm',
         name: 'exampleRequired',
         message:
-          'Do you want a cool page example which demonstrates the best practices (Y/n) ?',
+          'Do you want a cool page example which demonstrates the best practices?',
         default: true,
       },
     ];
@@ -26,7 +26,7 @@ class StackGenerator extends Generator {
         type: 'confirm',
         name: 'empty-folder',
         message:
-          'The current folder must be empty, even of hidden files, do you confirm (Y/n) ?',
+          'The current folder must be empty, even of hidden files, do you confirm?',
         default: true,
       });
     }


### PR DESCRIPTION
Redundant indication as shown below and used [here](https://github.com/theodo/theodo-stack-generator/blob/c811c0dfc15471cc0633f1df7d9b941a62bf3f29/generators/app/index.js#L17-L20).

<img width="644" alt="capture d ecran 2018-03-13 a 15 49 22" src="https://user-images.githubusercontent.com/11637509/37349570-0ec3c54e-26d7-11e8-98d2-83bf36be3f03.png">

