### PR TITLE
Fix appName in templates when generating app

### DIFF
--- a/generators/react/index.js
+++ b/generators/react/index.js
@@ -4,9 +4,6 @@ const chalk = require('chalk');
 class StackGenerator extends Generator {
   constructor(args, opts) {
     super(args, opts);
-    this.option('appName');
-    this.option('clientRequired');
-    this.option('serverRequired');
   }
 
   prompting() {

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -3,9 +3,6 @@ const Generator = require('yeoman-generator');
 class StackGenerator extends Generator {
   constructor(args, opts) {
     super(args, opts);
-    this.option('appName');
-    this.option('clientRequired');
-    this.option('serverRequired');
   }
 
   prompting() {


### PR DESCRIPTION
Resolve the issue : https://github.com/theodo/theodo-stack-generator/issues/75

According to the Yeoman documentation (http://yeoman.io/authoring/), the `this.option` method of the `Generator` class is used to specify the generator that a command line option (like `--appName`) can be used. Which, in our case, conflict with the prompt options.