### PR TITLE
Adapt component generator

### DIFF
--- a/generators/react/templates/scripts/generators/component/container.js.hbs
+++ b/generators/react/templates/scripts/generators/component/container.js.hbs
@@ -3,7 +3,6 @@ import { connect } from 'react-redux';
 {{#if wantMessages}}
 import { injectIntl } from 'react-intl';
 {{/if}}
-import { toJS } from '../../services/immutable/toJs';
 
 import {{ properCase name }} from './{{ properCase name }}.component';
 
@@ -17,9 +16,9 @@ const mapDispatchToProps = (dispatch: Dispatch) => {
 
 export default connect(mapStateToProps, mapDispatchToProps)(
   {{#if wantMessages}}
-  injectIntl(toJS({{ properCase name }})),
+  injectIntl({{ properCase name }}),
   {{/if}}
   {{#unless wantMessages}}
-  toJS({{ properCase name }}),
+  {{ properCase name }},
   {{/unless}}
 );

--- a/generators/react/templates/scripts/generators/component/snapshot.test.js.hbs
+++ b/generators/react/templates/scripts/generators/component/snapshot.test.js.hbs
@@ -4,13 +4,15 @@ import {{ properCase name }} from './{{ properCase name }}.component';
 import createComponentWithIntl from 'services/i18n/create-component-with-intl';
 
 describe('[Snapshot] <{{ properCase name }} />', () => {
-  it('should render correctly', () => {
+  it('should render a button with a label', () => {
     const props = {
+      {{#if wantMessages}}
       intl: {
         formatMessage: jest.fn(),
       },
+      {{/if}}
     };
-    const tree = createComponentWithIntl(<{{ properCase name }} {...props} />).toJSON();
-    expect(tree).toMatchSnapshot();
+    const wrapper = shallow(<{{ properCase name }} {...props} />);
+    expect(toJson(wrapper)).toMatchSnapshot();
   });
 });

--- a/generators/react/templates/scripts/generators/component/snapshot.test.js.hbs
+++ b/generators/react/templates/scripts/generators/component/snapshot.test.js.hbs
@@ -3,6 +3,10 @@ import React from 'react';
 import {{ properCase name }} from './{{ properCase name }}.component';
 import createComponentWithIntl from 'services/i18n/create-component-with-intl';
 
+/*
+Snapshot tests allow you to easily lock the comportment of a component.
+Given props, it renders the component and compares it to the saved snapshot.
+*/
 describe('[Snapshot] <{{ properCase name }} />', () => {
   it('should render a button with a label', () => {
     const props = {

--- a/generators/react/templates/scripts/generators/component/test.js.hbs
+++ b/generators/react/templates/scripts/generators/component/test.js.hbs
@@ -1,19 +1,26 @@
 // @flow
 import React from 'react';
 import { shallow } from 'enzyme';
+import toJson from 'enzyme-to-json';
 
 import {{ properCase name }} from './{{ properCase name }}.component';
 
 let wrapper = null;
 
 describe('[Component] <{{ properCase name }} />', () => {
-  const props = {};
+  const props = {
+    {{#if wantMessages}}
+    intl: {
+      formatMessage: jest.fn(),
+    },
+    {{/if}}
+  };
 
   beforeEach(() => {
     wrapper = shallow(<{{ properCase name }} {...props} />);
   });
 
-  it('should exist', () => {
+  it('should be a test with an explicit name', () => {
     expect(wrapper.exists()).toEqual(true);
   });
 });

--- a/generators/react/templates/scripts/generators/component/test.js.hbs
+++ b/generators/react/templates/scripts/generators/component/test.js.hbs
@@ -7,6 +7,13 @@ import {{ properCase name }} from './{{ properCase name }}.component';
 
 let wrapper = null;
 
+/*
+This file contains all unit tests. The standard is:
+  - The name of the test is explicit.
+  - The test file contains tests for each of the function use cases.
+  - The test is testing one action only.
+  - The test can fail.
+*/
 describe('[Component] <{{ properCase name }} />', () => {
   const props = {
     {{#if wantMessages}}

--- a/generators/react/templates/scripts/generators/component/test.js.hbs
+++ b/generators/react/templates/scripts/generators/component/test.js.hbs
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react';
 import { shallow } from 'enzyme';
-import toJson from 'enzyme-to-json';
 
 import {{ properCase name }} from './{{ properCase name }}.component';
 


### PR DESCRIPTION
@tcheymol Changements embarqués dans cette PR : 

- Noms de scénarios de tests explicites => OK
-Commentaires pou savoir à quoi sert chaque test, voir comment écrire des bons tests
- Flow partout => OK
- Pas de problème avec les injections de intl, … (je crois avoir vu que quand tu génères un composant sans intl t’as quand meme la prop dans le test et le composant) => OK
- Enlever Immutable => OK
- Tests avec airbnb et pas react-test-renderer **=> KO**