### PR TITLE
feat(eslint-rules): add rule to prevent user from using array index as key in react

### DIFF
--- a/generators/react-lint/templates/.eslintrc
+++ b/generators/react-lint/templates/.eslintrc
@@ -49,6 +49,7 @@
     "react/prefer-stateless-function": 0,
     "react/require-default-props": 0,
     "react/prop-types": 0,
+    "react/no-array-index-key": 2,
     "import/prefer-default-export": 0,
     "import/no-extraneous-dependencies": 0,
     "import/no-unresolved": 0,


### PR DESCRIPTION
Using array index as a key is a bad practice that created bugs in my project (CIB) so I suggest this MR to prevent this to happen on all the future Theodo projects